### PR TITLE
Add Kotlinx Serialization to FLK

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ org.jetbrains.kotlin:kotlin-reflect:1.4.21
 org.jetbrains:annotations:20.0.0
 org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2
 org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.4.2
+org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.0.1
+org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.0.1
 ```
 
 ## Available Versions

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,7 +85,7 @@ dependencies {
     includeAndExpose(Jetbrains.KotlinX.Coroutines.coreJvm)
     includeAndExpose(Jetbrains.KotlinX.Coroutines.jdk8)
     includeAndExpose(Jetbrains.KotlinX.Serialization.coreJvm)
-    includeAndExpose(Jetbrains.KotlinX.Serialization.coreJson)
+    includeAndExpose(Jetbrains.KotlinX.Serialization.jsonJvm)
 }
 
 val remapJar = tasks.getByName<RemapJarTask>("remapJar")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,6 @@ import com.matthewprenger.cursegradle.CurseUploadTask
 import com.matthewprenger.cursegradle.Options
 import net.fabricmc.loom.task.RemapJarTask
 import net.fabricmc.loom.task.RemapSourcesJarTask
-import java.util.Properties
 
 plugins {
     kotlin("jvm") version Jetbrains.Kotlin.version
@@ -85,8 +84,8 @@ dependencies {
     includeAndExpose(Jetbrains.KotlinX.Coroutines.core)
     includeAndExpose(Jetbrains.KotlinX.Coroutines.coreJvm)
     includeAndExpose(Jetbrains.KotlinX.Coroutines.jdk8)
-    includeAndExpose(Jetbrains.KotlinX.Serialization.core)
-    includeAndExpose(Jetbrains.KotlinX.Serialization.json)
+    includeAndExpose(Jetbrains.KotlinX.Serialization.coreJvm)
+    includeAndExpose(Jetbrains.KotlinX.Serialization.coreJson)
 }
 
 val remapJar = tasks.getByName<RemapJarTask>("remapJar")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,6 +85,8 @@ dependencies {
     includeAndExpose(Jetbrains.KotlinX.Coroutines.core)
     includeAndExpose(Jetbrains.KotlinX.Coroutines.coreJvm)
     includeAndExpose(Jetbrains.KotlinX.Coroutines.jdk8)
+    includeAndExpose(Jetbrains.KotlinX.Serialization.core)
+    includeAndExpose(Jetbrains.KotlinX.Serialization.json)
 }
 
 val remapJar = tasks.getByName<RemapJarTask>("remapJar")
@@ -183,7 +185,9 @@ tasks.create<Copy>("processMDTemplates") {
             "BUNDLED_REFLECT" to Jetbrains.Kotlin.version,
             "BUNDLED_ANNOTATIONS" to Jetbrains.Annotations.version,
             "BUNDLED_COROUTINES_CORE" to Jetbrains.KotlinX.Coroutines.version,
-            "BUNDLED_COROUTINES_JDK8" to Jetbrains.KotlinX.Coroutines.version
+            "BUNDLED_COROUTINES_JDK8" to Jetbrains.KotlinX.Coroutines.version,
+            "BUNDLED_SERIALIZATION_CORE" to Jetbrains.KotlinX.Serialization.version,
+            "BUNDLED_SERIALIZATION_JSON" to Jetbrains.KotlinX.Serialization.version
         )
     }
     destinationDir = rootDir

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -21,7 +21,11 @@ object Jetbrains {
             const val coreJvm = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$version"
             const val jdk8 = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$version"
         }
-
+        object Serialization {
+            const val version = "1.0.1"
+            const val core = "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:$version"
+            const val json = "org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:$version"
+        }
     }
 }
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -23,8 +23,8 @@ object Jetbrains {
         }
         object Serialization {
             const val version = "1.0.1"
-            const val core = "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:$version"
-            const val json = "org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:$version"
+            const val coreJvm = "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:$version"
+            const val coreJson = "org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:$version"
         }
     }
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -24,7 +24,7 @@ object Jetbrains {
         object Serialization {
             const val version = "1.0.1"
             const val coreJvm = "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:$version"
-            const val coreJson = "org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:$version"
+            const val jsonJvm = "org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:$version"
         }
     }
 }


### PR DESCRIPTION
Kotlinx Serialization is just as much an official Kotlin library as Coroutines is, so it would make sense to bundle it into FLK along with Stdlib, Reflect and Coroutines.

This also "fixes" #34. That actually seems to be a Loom issue, as Loom is not removing the Kotlin Jars when Gradle runs. However, that's a different issue and I should probably move it to the Loom repository.