### PR TITLE
Change URLs to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Repositories for build.gradle.kts
 ```kotlin
 repositories {
     // [...]
-    maven(url = "http://maven.fabricmc.net/") {
+    maven(url = "https://maven.fabricmc.net/") {
         name = "Fabric"
     }
 }
@@ -23,7 +23,7 @@ Repositories for build.gradle:
 repositories {
     // [...]
     maven {
-        url = "http://maven.fabricmc.net/"
+        url = "https://maven.fabricmc.net/"
         name = "Fabric"
     }
 }


### PR DESCRIPTION
Using insecure protocols causes an exception with fabric-example-mod on Gradle 1.7 with Java 16.