### PR TITLE
Add kotlinx.serialization cbor module

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2
 org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.5.2
 org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.3.0
 org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.3.0
+org.jetbrains.kotlinx:kotlinx-serialization-cbor-jvm:1.3.1
 ```
 
 ## Available Versions

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,6 +88,7 @@ dependencies {
     includeAndExpose(Jetbrains.KotlinX.Coroutines.jdk8)
     includeAndExpose(Jetbrains.KotlinX.Serialization.coreJvm)
     includeAndExpose(Jetbrains.KotlinX.Serialization.jsonJvm)
+    includeAndExpose(Jetbrains.KotlinX.Serialization.cborJvm)
 }
 
 val remapJar = tasks.getByName<RemapJarTask>("remapJar")

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -19,6 +19,7 @@ object Jetbrains {
             const val version = "1.3.0"
             const val coreJvm = "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:$version"
             const val jsonJvm = "org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:$version"
+            const val cborJvm = "org.jetbrains.kotlinx:kotlinx-serialization-cbor-jvm:$version"
         }
     }
 }


### PR DESCRIPTION
Added the [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization) cbor module. For some parts of the of the API this module provides users will have to opt in to experimental features, but that is entirely their decision.
Cbor is the only other well maintained official format for kotlinx.serialization next to Json.
In a lot of cases this format is better fitting for modding than the Json format, because it is a binary one.

*Note that I have already added the most recent version to the readme, assuming that this gets merged after the 1.6.0 update PR*