### PR TITLE
Add atomicfu library

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.1
 org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.3.2
 org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.3.2
 org.jetbrains.kotlinx:kotlinx-serialization-cbor-jvm:1.3.2
+org.jetbrains.kotlinx:atomicfu-jvm:0.17.3
 ```
 
 ## Available Versions

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ val loaderVersion: String by project
 val kotlinVersion: String by project
 val coroutinesVersion: String by project
 val serializationVersion: String by project
+val atomicfuVersion: String by project
 
 base {
     archivesBaseName = modId
@@ -79,6 +80,7 @@ dependencies {
     includeAndExpose("org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:$serializationVersion")
     includeAndExpose("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:$serializationVersion")
     includeAndExpose("org.jetbrains.kotlinx:kotlinx-serialization-cbor-jvm:$serializationVersion")
+    includeAndExpose("org.jetbrains.kotlinx:atomicfu-jvm:$atomicfuVersion")
 }
 
 java {
@@ -169,7 +171,8 @@ tasks.create<Copy>("processMDTemplates") {
             "LOADER_VERSION" to loaderVersion,
             "KOTLIN_VERSION" to kotlinVersion,
             "COROUTINES_VERSION" to coroutinesVersion,
-            "SERIALIZATION_VERSION" to serializationVersion
+            "SERIALIZATION_VERSION" to serializationVersion,
+            "ATOMICFU_VERSION" to atomicfuVersion,
         )
     }
     destinationDir = rootDir

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,4 @@ description=Fabric language module for Kotlin
 kotlinVersion=1.6.21
 coroutinesVersion=1.6.1
 serializationVersion=1.3.2
+atomicfuVersion=0.17.3

--- a/templates/README.template.md
+++ b/templates/README.template.md
@@ -249,6 +249,7 @@ org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:${COROUTINES_VERSION}
 org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:${SERIALIZATION_VERSION}
 org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:${SERIALIZATION_VERSION}
 org.jetbrains.kotlinx:kotlinx-serialization-cbor-jvm:${SERIALIZATION_VERSION}
+org.jetbrains.kotlinx:atomicfu-jvm:${ATOMICFU_VERSION}
 ```
 
 ## Available Versions


### PR DESCRIPTION
This library is the companion for the atomicfu compiler plugin, which makes it possible to mark any property as atomic.
It should be preferred over Java atomics in Kotlin code.
Since the library reached beta stability, it should be included in fabric-language-kotlin.

It is part of the kotlinx core libraries.

https://github.com/Kotlin/kotlinx.atomicfu