### PR TITLE
Add kotlinx-datetime library

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.1
 org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.3.2
 org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.3.2
 org.jetbrains.kotlinx:kotlinx-serialization-cbor-jvm:1.3.2
+org.jetbrains.kotlinx:kotlinx-datetime-jvm:0.3.2
 ```
 
 ## Available Versions

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.1
 org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.3.2
 org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.3.2
 org.jetbrains.kotlinx:kotlinx-serialization-cbor-jvm:1.3.2
-org.jetbrains.kotlinx:kotlinx-datetime-jvm:0.3.2
+org.jetbrains.kotlinx:kotlinx-datetime-jvm:0.3.3
 ```
 
 ## Available Versions

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ val loaderVersion: String by project
 val kotlinVersion: String by project
 val coroutinesVersion: String by project
 val serializationVersion: String by project
+val datetimeVersion: String by project
 
 base {
     archivesBaseName = modId
@@ -79,6 +80,7 @@ dependencies {
     includeAndExpose("org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:$serializationVersion")
     includeAndExpose("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:$serializationVersion")
     includeAndExpose("org.jetbrains.kotlinx:kotlinx-serialization-cbor-jvm:$serializationVersion")
+    includeAndExpose("org.jetbrains.kotlinx:kotlinx-datetime-jvm:$datetimeVersion")
 }
 
 java {
@@ -169,7 +171,8 @@ tasks.create<Copy>("processMDTemplates") {
             "LOADER_VERSION" to loaderVersion,
             "KOTLIN_VERSION" to kotlinVersion,
             "COROUTINES_VERSION" to coroutinesVersion,
-            "SERIALIZATION_VERSION" to serializationVersion
+            "SERIALIZATION_VERSION" to serializationVersion,
+            "DATETIME_VERSION" to datetimeVersion,
         )
     }
     destinationDir = rootDir

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,4 @@ description=Fabric language module for Kotlin
 kotlinVersion=1.6.21
 coroutinesVersion=1.6.1
 serializationVersion=1.3.2
+datetimeVersion=0.3.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,4 @@ description=Fabric language module for Kotlin
 kotlinVersion=1.6.21
 coroutinesVersion=1.6.1
 serializationVersion=1.3.2
-datetimeVersion=0.3.2
+datetimeVersion=0.3.3

--- a/templates/README.template.md
+++ b/templates/README.template.md
@@ -249,6 +249,7 @@ org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:${COROUTINES_VERSION}
 org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:${SERIALIZATION_VERSION}
 org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:${SERIALIZATION_VERSION}
 org.jetbrains.kotlinx:kotlinx-serialization-cbor-jvm:${SERIALIZATION_VERSION}
+org.jetbrains.kotlinx:kotlinx-datetime-jvm:${DATETIME_VERSION}
 ```
 
 ## Available Versions


### PR DESCRIPTION
The kotlinx-datetime library provides Kotlin multiplatform support for datetime related things like `Instant`, `Clock`, `LocalDateTime` and so on.
These classes are also serializable with kotlinx.serialization by default.

The stability of this library is in `alpha`, which in Kotlin terms means that the project has been officially picked up and is no longer experimental - it can be used, but the API might change and enterprises shouldn't use it in production.

It is part of the core kotlinx libraries.

https://github.com/Kotlin/kotlinx-datetime