### PR TITLE
Update to Kotlin 1.7.0 and bump coroutines and serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add it as a dependency (build.gradle and build.gradle.kts):
 ```kotlin
 dependencies {
     // [...]
-    modImplementation(group = "net.fabricmc", name = "fabric-language-kotlin", version = "1.7.4+kotlin.1.6.21")
+    modImplementation(group = "net.fabricmc", name = "fabric-language-kotlin", version = "1.7.5+kotlin.1.6.21")
 }
 ```
 
@@ -31,7 +31,7 @@ Remember to the add a dependency entry to your `fabric.mod.json` file:
         ]
     },
     "depends": {
-        "fabric-language-kotlin": ">=1.7.4+kotlin.1.6.21"
+        "fabric-language-kotlin": ">=1.7.5+kotlin.1.6.21"
     }
 }
 ```
@@ -244,11 +244,11 @@ See examples in [sample-mod/fabric.mod.json](https://github.com/FabricMC/fabric-
 ```
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21
 org.jetbrains.kotlin:kotlin-reflect:1.6.21
-org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1
-org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.1
-org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.3.2
-org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.3.2
-org.jetbrains.kotlinx:kotlinx-serialization-cbor-jvm:1.3.2
+org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.2
+org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.2
+org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.3.3
+org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.3.3
+org.jetbrains.kotlinx:kotlinx-serialization-cbor-jvm:1.3.3
 ```
 
 ## Available Versions

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add it as a dependency (build.gradle and build.gradle.kts):
 ```kotlin
 dependencies {
     // [...]
-    modImplementation(group = "net.fabricmc", name = "fabric-language-kotlin", version = "1.7.5+kotlin.1.6.21")
+    modImplementation(group = "net.fabricmc", name = "fabric-language-kotlin", version = "1.8.0+kotlin.1.7.0")
 }
 ```
 
@@ -31,7 +31,7 @@ Remember to the add a dependency entry to your `fabric.mod.json` file:
         ]
     },
     "depends": {
-        "fabric-language-kotlin": ">=1.7.5+kotlin.1.6.21"
+        "fabric-language-kotlin": ">=1.8.0+kotlin.1.7.0"
     }
 }
 ```
@@ -242,8 +242,8 @@ See examples in [sample-mod/fabric.mod.json](https://github.com/FabricMC/fabric-
 ## Bundled libraries
 
 ```
-org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21
-org.jetbrains.kotlin:kotlin-reflect:1.6.21
+org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.0
+org.jetbrains.kotlin:kotlin-reflect:1.7.0
 org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.2
 org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.2
 org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.3.3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ import net.fabricmc.loom.task.RemapJarTask
 import net.fabricmc.loom.task.RemapSourcesJarTask
 
 plugins {
-    kotlin("jvm") version "1.6.20"
+    kotlin("jvm") version "1.7.0"
     id("org.cadixdev.licenser") version "0.6.1"
     id("com.matthewprenger.cursegradle") version "1.4.0"
     id("fabric-loom") version "0.10-SNAPSHOT"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@ org.gradle.jvmargs=-Xmx2G
 CURSEFORGE_ID=308769
 
 modId=fabric-language-kotlin
-modVersion=1.7.4
+modVersion=1.7.5
 minecraftVersion=1.16.5
 loaderVersion=0.12.12
 group=net.fabricmc
 description=Fabric language module for Kotlin
 
 kotlinVersion=1.6.21
-coroutinesVersion=1.6.1
-serializationVersion=1.3.2
+coroutinesVersion=1.6.2
+serializationVersion=1.3.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@ org.gradle.jvmargs=-Xmx2G
 CURSEFORGE_ID=308769
 
 modId=fabric-language-kotlin
-modVersion=1.7.5
+modVersion=1.8.0
 minecraftVersion=1.16.5
 loaderVersion=0.12.12
 group=net.fabricmc
 description=Fabric language module for Kotlin
 
-kotlinVersion=1.6.21
+kotlinVersion=1.7.0
 coroutinesVersion=1.6.2
 serializationVersion=1.3.3


### PR DESCRIPTION
Updates coroutines and serialization for Kotlin 1.6.21.
This also increases the mod version to 1.8.0.