### PR TITLE
Update libraries for 1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add it as a dependency to your Gradle project:
 
 ```kotlin
 dependencies {
-    modImplementation("net.fabricmc:fabric-language-kotlin:1.8.0+kotlin.1.7.0")
+    modImplementation("net.fabricmc:fabric-language-kotlin:1.8.1+kotlin.1.7.0")
 }
 ```
 
@@ -35,7 +35,7 @@ Remember to the add a dependency entry to your `fabric.mod.json` file:
         ]
     },
     "depends": {
-        "fabric-language-kotlin": ">=1.8.0+kotlin.1.7.0"
+        "fabric-language-kotlin": ">=1.8.1+kotlin.1.7.0"
     }
 }
 ```
@@ -240,13 +240,13 @@ Companion objects can be used by appending `$Companion` to the class.
 - **`kotlin-reflect`** 1.7.0 [Docs](https://kotlinlang.org/docs/reflection.html), [API docs](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/)
 
 `org.jetbrains.kotlinx` namespace:
-- **`kotlinx-coroutines-core`** 1.6.2 [Guide](https://kotlinlang.org/docs/coroutines-guide.html), [API docs](https://kotlin.github.io/kotlinx.coroutines/), [GitHub](https://github.com/Kotlin/kotlinx.coroutines)
-- **`kotlinx-coroutines-jdk8`** 1.6.2 [API docs](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-jdk8/index.html)
+- **`kotlinx-coroutines-core`** 1.6.3 [Guide](https://kotlinlang.org/docs/coroutines-guide.html), [API docs](https://kotlin.github.io/kotlinx.coroutines/), [GitHub](https://github.com/Kotlin/kotlinx.coroutines)
+- **`kotlinx-coroutines-jdk8`** 1.6.3 [API docs](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-jdk8/index.html)
 - **`kotlinx-serialization-core`** 1.3.3 [Guide](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serialization-guide.md), [API docs](https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/index.html), [GitHub](https://github.com/Kotlin/kotlinx.serialization)
 - **`kotlinx-serialization-json`** 1.3.3 [API docs](https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-json/index.html)
 - **`kotlinx-serialization-cbor`** 1.3.3 [API docs](https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-cbor/index.html)
-- **`atomicfu`** 0.17.3 [GitHub](https://github.com/Kotlin/kotlinx.atomicfu)
-- **`kotlinx-datetime`** 0.3.3 [GitHub](https://github.com/Kotlin/kotlinx-datetime)
+- **`atomicfu`** 0.18.0 [GitHub](https://github.com/Kotlin/kotlinx.atomicfu)
+- **`kotlinx-datetime`** 0.4.0 [GitHub](https://github.com/Kotlin/kotlinx-datetime)
 
 ## Available Versions
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2G
 
 modId=fabric-language-kotlin
-modVersion=1.8.0
+modVersion=1.8.1
 minecraftVersion=1.19
 mappingsVersion=1.19+build.1
 loaderVersion=0.14.7
@@ -10,7 +10,7 @@ group=net.fabricmc
 description=Fabric language module for Kotlin
 
 kotlinVersion=1.7.0
-coroutinesVersion=1.6.2
+coroutinesVersion=1.6.3
 serializationVersion=1.3.3
-atomicfuVersion=0.17.3
-datetimeVersion=0.3.3
+atomicfuVersion=0.18.0
+datetimeVersion=0.4.0


### PR DESCRIPTION
This updates kotlinx-datetime to 0.4.0, atomicfu to 0.18.0 and includes a minor version bump for kotlinx.coroutines to 1.6.3.

This PR bumps the mod version to 1.8.1.