### PR TITLE
Update to Kotlin 1.7.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add it as a dependency to your Gradle project:
 
 ```kotlin
 dependencies {
-    modImplementation("net.fabricmc:fabric-language-kotlin:1.8.1+kotlin.1.7.0")
+    modImplementation("net.fabricmc:fabric-language-kotlin:1.8.2+kotlin.1.7.10")
 }
 ```
 
@@ -35,7 +35,7 @@ Remember to the add a dependency entry to your `fabric.mod.json` file:
         ]
     },
     "depends": {
-        "fabric-language-kotlin": ">=1.8.1+kotlin.1.7.0"
+        "fabric-language-kotlin": ">=1.8.2+kotlin.1.7.10"
     }
 }
 ```
@@ -236,16 +236,16 @@ Companion objects can be used by appending `$Companion` to the class.
 ## Bundled libraries
 
 `org.jetbrains.kotlin` namespace:
-- **`kotlin-stdlib`** 1.7.0 [Docs](https://kotlinlang.org/docs/home.html), [API docs](https://kotlinlang.org/api/latest/jvm/stdlib/), [GitHub](https://github.com/JetBrains/kotlin)
-- **`kotlin-reflect`** 1.7.0 [Docs](https://kotlinlang.org/docs/reflection.html), [API docs](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/)
+- **`kotlin-stdlib`** 1.7.10 [Docs](https://kotlinlang.org/docs/home.html), [API docs](https://kotlinlang.org/api/latest/jvm/stdlib/), [GitHub](https://github.com/JetBrains/kotlin)
+- **`kotlin-reflect`** 1.7.10 [Docs](https://kotlinlang.org/docs/reflection.html), [API docs](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/)
 
 `org.jetbrains.kotlinx` namespace:
-- **`kotlinx-coroutines-core`** 1.6.3 [Guide](https://kotlinlang.org/docs/coroutines-guide.html), [API docs](https://kotlin.github.io/kotlinx.coroutines/), [GitHub](https://github.com/Kotlin/kotlinx.coroutines)
-- **`kotlinx-coroutines-jdk8`** 1.6.3 [API docs](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-jdk8/index.html)
+- **`kotlinx-coroutines-core`** 1.6.4 [Guide](https://kotlinlang.org/docs/coroutines-guide.html), [API docs](https://kotlin.github.io/kotlinx.coroutines/), [GitHub](https://github.com/Kotlin/kotlinx.coroutines)
+- **`kotlinx-coroutines-jdk8`** 1.6.4 [API docs](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-jdk8/index.html)
 - **`kotlinx-serialization-core`** 1.3.3 [Guide](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serialization-guide.md), [API docs](https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/index.html), [GitHub](https://github.com/Kotlin/kotlinx.serialization)
 - **`kotlinx-serialization-json`** 1.3.3 [API docs](https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-json/index.html)
 - **`kotlinx-serialization-cbor`** 1.3.3 [API docs](https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-cbor/index.html)
-- **`atomicfu`** 0.18.0 [GitHub](https://github.com/Kotlin/kotlinx.atomicfu)
+- **`atomicfu`** 0.18.2 [GitHub](https://github.com/Kotlin/kotlinx.atomicfu)
 - **`kotlinx-datetime`** 0.4.0 [GitHub](https://github.com/Kotlin/kotlinx-datetime)
 
 ## Available Versions

--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,10 @@ buildscript {
 }
 
 plugins {
-    id 'fabric-loom' version '0.12.48'
+    id 'fabric-loom' version '0.12.54'
     id 'maven-publish'
     id "com.matthewprenger.cursegradle" version "1.4.0"
-    id "org.jetbrains.kotlin.jvm" version "1.7.0"
+    id "org.jetbrains.kotlin.jvm" version "1.7.10"
     id "com.diffplug.spotless" version "6.5.1"
     id "com.modrinth.minotaur" version "1.1.0"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,15 +2,15 @@ kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2G
 
 modId=fabric-language-kotlin
-modVersion=1.8.1
+modVersion=1.8.2
 minecraftVersion=1.19
 mappingsVersion=1.19+build.1
 loaderVersion=0.14.7
 group=net.fabricmc
 description=Fabric language module for Kotlin
 
-kotlinVersion=1.7.0
-coroutinesVersion=1.6.3
+kotlinVersion=1.7.10
+coroutinesVersion=1.6.4
 serializationVersion=1.3.3
-atomicfuVersion=0.18.0
+atomicfuVersion=0.18.2
 datetimeVersion=0.4.0


### PR DESCRIPTION
This updates Kotlin to 1.7.10 and includes some minor version bumps for the kotlinx libraries:
 - coroutines 1.6.3 -> 1.6.4
 - atomicfu 0.18.0 -> 0.18.2

This also updates fabric-loom to 0.12.54.