### PR TITLE
Remove stdlib-jdk8 and stdlib-jdk7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,6 @@ def KOTLIN_VERSION_FILE = "generated/kotlin_version.txt"
 def kotlinLib = "org.jetbrains.kotlin:kotlin-stdlib"
 def libraries = [
         kotlinLib,
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
         "org.jetbrains.kotlin:kotlin-reflect",
 
         "org.jetbrains.kotlinx:kotlinx-coroutines-core",

--- a/generated/library_versions.json
+++ b/generated/library_versions.json
@@ -1,7 +1,5 @@
 {
     "org.jetbrains.kotlin:kotlin-stdlib": "1.8.0",
-    "org.jetbrains.kotlin:kotlin-stdlib-jdk8": "1.8.0",
-    "org.jetbrains.kotlin:kotlin-stdlib-jdk7": "1.8.0",
     "org.jetbrains.kotlin:kotlin-reflect": "1.8.0",
     "org.jetbrains.kotlinx:kotlinx-coroutines-core": "1.6.4",
     "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": "1.6.4",


### PR DESCRIPTION
See:  <https://kotlinlang.org/docs/whatsnew18.html#updated-jvm-compilation-target>

These libraries are currently just empty shells. I don't believe there is a major rush to remove these, having them in place does mean that the older versions cannot be included by other mods.