### PR TITLE
Add library badge

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,5 +20,12 @@
   "icon": "assets/fabric-language-kotlin/icon500.png",
   "depends": {
     "fabricloader": ">=0.14.7"
+  },
+  "custom": {
+    "modmenu": {
+      "badges": [
+        "library"
+      ]
+    }
   }
 }


### PR DESCRIPTION
Specifies to Mod Menu that the mod is a library/dependency so that users can optionally hide it in their mod list.