### PR TITLE
Minor code cleanup

### DIFF
--- a/src/main/kotlin/net/fabricmc/language/kotlin/KotlinAdapter.kt
+++ b/src/main/kotlin/net/fabricmc/language/kotlin/KotlinAdapter.kt
@@ -105,7 +105,7 @@ open class KotlinAdapter : LanguageAdapter {
                     MethodHandles.lookup()
                         .unreflect(methodList[0].javaMethod)
                         .bindTo(instance)
-                } catch (ex: java.lang.Exception) {
+                } catch (ex: Exception) {
                     throw LanguageAdapterException("Failed to create method handle for $value!", ex)
                 }
 


### PR DESCRIPTION
No longer use internal/deprecated fabric-loader classes.
Use MethodHandleProxies, matching the default language adapter.