### PR TITLE
Dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,10 @@ buildscript {
 }
 
 plugins {
-    id 'fabric-loom' version '1.4.4'
+    id 'fabric-loom' version '1.5-SNAPSHOT'
     id 'maven-publish'
-    id "com.diffplug.spotless" version "6.19.0"
-    id 'me.modmuss50.mod-publish-plugin' version '0.4.1'
+    id "com.diffplug.spotless" version "6.25.0"
+    id 'me.modmuss50.mod-publish-plugin' version '0.5.1'
 }
 
 apply plugin: "org.jetbrains.kotlin.jvm"
@@ -75,10 +75,10 @@ configurations.all {
 }
 
 dependencies {
-    minecraft "com.mojang:minecraft:${project.minecraftVersion}"
-    mappings "net.fabricmc:yarn:${project.mappingsVersion}:v2"
-    modImplementation "net.fabricmc:fabric-loader:${project.loaderVersion}"
-	testImplementation "net.fabricmc:fabric-loader-junit:${project.loaderVersion}"
+    minecraft "com.mojang:minecraft:${project.minecraft_version}"
+    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	testImplementation "net.fabricmc:fabric-loader-junit:${project.loader_version}"
 	testImplementation "org.jetbrains.kotlin:kotlin-test"
 
     if (hasMissingLibVersion) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,9 @@ org.gradle.jvmargs=-Xmx2G
 
 modId=fabric-language-kotlin
 modVersion=1.10.19
-minecraftVersion=1.20.2
-mappingsVersion=1.20.2+build.4
-loaderVersion=0.14.24
+minecraft_version=1.20.4
+yarn_mappings=1.20.4+build.3
+loader_version=0.15.7
+
 group=net.fabricmc
 description=Fabric language module for Kotlin

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
I saw that `LanguageAdapter` and other classes in `loader.language` got Deprecated in Fabric Loader not sure why or what to use instead. Should still work fine