### PR TITLE
add kotlinx-io library

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ Companion objects can be used by appending `$Companion` to the class.
 - **`kotlinx-serialization-cbor`** 1.6.3 [API docs](https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-cbor/index.html)
 - **`atomicfu`** 0.24.0 [GitHub](https://github.com/Kotlin/kotlinx.atomicfu)
 - **`kotlinx-datetime`** 0.6.0 [GitHub](https://github.com/Kotlin/kotlinx-datetime)
+- **`kotlinx-io-core`** 0.5.1 [API docs](https://kotlin.github.io/kotlinx-io/kotlinx-io-core/index.html) [GitHub](https://github.com/Kotlin/kotlinx-io)
+- **`kotlinx-io-bytestring`** 0.5.1 [API docs](https://kotlin.github.io/kotlinx-io/kotlinx-io-bytestring/index.html)
 
 ## Available Versions
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,8 @@ def libraries = [
         "org.jetbrains.kotlinx:kotlinx-serialization-json-jvm",
         "org.jetbrains.kotlinx:kotlinx-serialization-cbor-jvm",
         "org.jetbrains.kotlinx:atomicfu-jvm",
-        "org.jetbrains.kotlinx:kotlinx-datetime-jvm"
+        "org.jetbrains.kotlinx:kotlinx-datetime-jvm",
+        "org.jetbrains.kotlinx:kotlinx-io-core-jvm"
 ]
 
 def libVersions = new JsonSlurper().parse(file(LIBRARY_VERSIONS_FILE))

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,8 @@ def libraries = [
         "org.jetbrains.kotlinx:kotlinx-serialization-cbor-jvm",
         "org.jetbrains.kotlinx:atomicfu-jvm",
         "org.jetbrains.kotlinx:kotlinx-datetime-jvm",
-        "org.jetbrains.kotlinx:kotlinx-io-core-jvm"
+        "org.jetbrains.kotlinx:kotlinx-io-core-jvm",
+        "org.jetbrains.kotlinx:kotlinx-io-bytestring-jvm"
 ]
 
 def libVersions = new JsonSlurper().parse(file(LIBRARY_VERSIONS_FILE))

--- a/generated/library_versions.json
+++ b/generated/library_versions.json
@@ -11,5 +11,6 @@
     "org.jetbrains.kotlinx:kotlinx-serialization-cbor-jvm": "1.6.3",
     "org.jetbrains.kotlinx:atomicfu-jvm": "0.24.0",
     "org.jetbrains.kotlinx:kotlinx-datetime-jvm": "0.6.0",
-    "org.jetbrains.kotlinx:kotlinx-io-core-jvm": "0.5.1"
+    "org.jetbrains.kotlinx:kotlinx-io-core-jvm": "0.5.1",
+    "org.jetbrains.kotlinx:kotlinx-io-bytestring-jvm": "0.5.1"
 }

--- a/generated/library_versions.json
+++ b/generated/library_versions.json
@@ -10,5 +10,6 @@
     "org.jetbrains.kotlinx:kotlinx-serialization-json-jvm": "1.6.3",
     "org.jetbrains.kotlinx:kotlinx-serialization-cbor-jvm": "1.6.3",
     "org.jetbrains.kotlinx:atomicfu-jvm": "0.24.0",
-    "org.jetbrains.kotlinx:kotlinx-datetime-jvm": "0.6.0"
+    "org.jetbrains.kotlinx:kotlinx-datetime-jvm": "0.6.0",
+    "org.jetbrains.kotlinx:kotlinx-io-core-jvm": "0.5.1"
 }

--- a/templates/README.template.md
+++ b/templates/README.template.md
@@ -247,6 +247,8 @@ Companion objects can be used by appending `\$Companion` to the class.
 - **`kotlinx-serialization-cbor`** ${KOTLINX_SERIALIZATION_CBOR_JVM_VERSION} [API docs](https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-cbor/index.html)
 - **`atomicfu`** ${ATOMICFU_JVM_VERSION} [GitHub](https://github.com/Kotlin/kotlinx.atomicfu)
 - **`kotlinx-datetime`** ${KOTLINX_DATETIME_JVM_VERSION} [GitHub](https://github.com/Kotlin/kotlinx-datetime)
+- **`kotlinx-io-core`** ${KOTLINX_IO_CORE_JVM_VERSION} [API docs](https://kotlin.github.io/kotlinx-io/kotlinx-io-core/index.html), [GitHub](https://github.com/Kotlin/kotlinx-io)
+- **`kotlinx-io-bytestring`** ${KOTLINX_IO_BYTESTRING_JVM_VERSION} [API docs](https://kotlin.github.io/kotlinx-io/kotlinx-io-bytestring/index.html)
 
 ## Available Versions
 


### PR DESCRIPTION
This PR adds the [kotlinx-io](https://github.com/Kotlin/kotlinx-io) library.
It is used by some mods and fits into the libraries this mod already provides.