### PR TITLE
Update push.yml to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,7 +16,7 @@ jobs:
         run: ./gradlew build publishMods --stacktrace --warning-mode=fail
       - name: 'Upload artifacts'
         if: ${{ matrix.java == '20' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Artifacts
           path: build/libs/


### PR DESCRIPTION
As discussed on the Fabric Discord server (`#toolchain-other`).

Bumping `actions/upload-artifact` to `v4` to prepare for the [deprecation of v3](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/).